### PR TITLE
Pyshtools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,13 @@ For reproducible analysis, we recommend installing CAP in a dedicated virtual en
     # Install CAP and its dependencies
     pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git
 
+    # For spectral analysis capabilities (recommended for conda), include
+    # the optional dependencies in the installation command:
+    # Method 1: Using conda (recommended):
+    conda env create -f environment.yml  # Creates environment with all dependencies including pyshtools
+    # Method 2: Using pip:
+    pip install amescap[spectral]        # Adds optional spectral analysis dependencies
+
     # Copy amescap_profile to your home directory, which varies by OS, shell, and package manager:
     # pip + Unix/MacOS (bash, csh, tcsh, zsh) OR Windows Cygwin:
     cp amescap/mars_templates/amescap_profile ~/.amescap_profile

--- a/README.rst
+++ b/README.rst
@@ -39,13 +39,10 @@ For reproducible analysis, we recommend installing CAP in a dedicated virtual en
 
     # Install CAP and its dependencies
     pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git
+    # OR install a specific branch with:
+    pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git@devel
 
-    # For spectral analysis capabilities (recommended for conda), include
-    # the optional dependencies in the installation command:
-    # Method 1: Using conda (recommended):
-    conda env create -f environment.yml  # Creates environment with all dependencies including pyshtools
-    # Method 2: Using pip:
-    pip install amescap[spectral]        # Adds optional spectral analysis dependencies
+    # For spectral analysis capabilities, please follow the installation instructions.
 
     # Copy amescap_profile to your home directory, which varies by OS, shell, and package manager:
     # pip + Unix/MacOS (bash, csh, tcsh, zsh) OR Windows Cygwin:
@@ -60,6 +57,8 @@ For reproducible analysis, we recommend installing CAP in a dedicated virtual en
     Copy-Item $env:USERPROFILE\anaconda3\envs\amescap\mars_templates\amescap-profile -Destination $HOME\.amescap-profile
 
 This ensures consistent package versions across different systems.
+
+For spectral analysis capabilities, please follow the `installation instructions <https://amescap.readthedocs.io/en/latest/installation.html>`_.
 
 Available Commands
 ^^^^^^^^^^^^^^^

--- a/amescap/Spectral_utils.py
+++ b/amescap/Spectral_utils.py
@@ -15,11 +15,8 @@ Third-party Requirements:
 
 # Load generic Python modules
 import numpy as np
-#TODO fix import
-#import pyshtools as pyshtools
 
-
-from amescap.Script_utils import Yellow, Cyan, Nclr, progress
+from amescap.Script_utils import Yellow, Nclr, progress
 
 try:
     from scipy.signal import butter, filtfilt, detrend
@@ -34,37 +31,25 @@ except Exception as exception:
 # ======================================================================
 #                           DEFINITIONS
 # ======================================================================
-#import pyshtools
-# def init_shtools():
-#     """
-#     The following code simply loads the pyshtools module and provides
-#     adequate referencing. Since dependencies may need to be solved by
-#     the user, the module import is wrapped in a function that can be
-#     called as needed.
-
-#     :raises: Exception
-
-#     :return: imported module pyshtools or error
-#     """
-#     try:
-#         import pyshtools as pyshtools
-#         print('Successfully imported pyshtools')
-#     except ImportError as error_msg:
-#         print(f"{Yellow}__________________\n"
-#               f"Zonal decomposition relies on the pyshtools library, "
-#               f"referenced at:\n\n"
-#               f"Mark A. Wieczorek and Matthias Meschede (2018). "
-#               f"SHTools - Tools for working with spherical harmonics,"
-#               f"Geochemistry, Geophysics, Geosystems, 2574-2592, "
-#               f"doi:10.1029/2018GC007529\n Please consult installation "
-#               f"instructions at:\n"
-#               f"{Cyan}https://pypi.org/project/pyshtools\n"
-#               f"{Yellow}And install with:\n"
-#               f"{Cyan}pip install pyshtools{Nclr}")
-#         exit()
-#     except Exception as exception:
-#         # Output unexpected Exceptions.
-#         print(f"{exception.__class__.__name__}: {exception}")
+# Try to import pyshtools with proper error handling
+try:
+    import pyshtools
+    PYSHTOOLS_AVAILABLE = True
+except ImportError:
+    PYSHTOOLS_AVAILABLE = False
+    print(
+        "\033[93m__________________\n"
+        "Zonal decomposition relies on the pyshtools library, "
+        "referenced at:\n\n"
+        "Mark A. Wieczorek and Matthias Meschede (2018). "
+        "SHTools - Tools for working with spherical harmonics,"
+        "Geochemistry, Geophysics, Geosystems, 2574-2592, "
+        "doi:10.1029/2018GC007529\n Please consult installation "
+        "instructions at:\n"
+        "\033[96mhttps://pypi.org/project/pyshtools\n"
+        "\033[93mAnd install with:\n"
+        "\033[96mconda install -c conda-forge pyshtools\033[0m"
+    )
 
 def diurn_extract(VAR, N, tod, lon):
     """
@@ -468,8 +453,13 @@ def zonal_decomposition(VAR):
         smallest dimension. This matches the Nyquist frequency.
         
     """
-    # TODO: Not optimal but prevent issues when library is not installed
-    #init_shtools()
+    if not PYSHTOOLS_AVAILABLE:
+        raise ImportError(
+            "This function requires pyshtools. Install with:\n"
+            "conda install -c conda-forge pyshtools\n"
+            "or\n"
+            "pip install amescap[spectral]"
+        )
 
     var_shape = np.array(VAR.shape)
 
@@ -524,8 +514,13 @@ def zonal_construct(COEFFS_flat, VAR_shape, btype=None, low_highcut=None):
               -> dx min = {L_min} km, dx max = {L_max} km")
               
     """
-    # Not optimal but prevent issues when library is not installed
-    #init_shtools()
+    if not PYSHTOOLS_AVAILABLE:
+        raise ImportError(
+            "This function requires pyshtools. Install with:\n"
+            "conda install -c conda-forge pyshtools\n"
+            "or\n"
+            "pip install amescap[spectral]"
+        )
 
     # Initialization
     nflatten = COEFFS_flat.shape[0]

--- a/amescap/Spectral_utils.py
+++ b/amescap/Spectral_utils.py
@@ -38,17 +38,19 @@ try:
 except ImportError:
     PYSHTOOLS_AVAILABLE = False
     print(
-        "\033[93m__________________\n"
-        "Zonal decomposition relies on the pyshtools library, "
-        "referenced at:\n\n"
-        "Mark A. Wieczorek and Matthias Meschede (2018). "
-        "SHTools - Tools for working with spherical harmonics,"
-        "Geochemistry, Geophysics, Geosystems, 2574-2592, "
-        "doi:10.1029/2018GC007529\n Please consult installation "
-        "instructions at:\n"
-        "\033[96mhttps://pypi.org/project/pyshtools\n"
-        "\033[93mAnd install with:\n"
-        "\033[96mconda install -c conda-forge pyshtools\033[0m"
+        f"{Yellow}__________________\n"
+        f"Zonal decomposition relies on the pyshtools library, "
+        f"referenced at:\n\n"
+        f"Mark A. Wieczorek and Matthias Meschede (2018). "
+        f"SHTools - Tools for working with spherical harmonics,"
+        f"Geochemistry, Geophysics, Geosystems, 2574-2592, "
+        f"doi:10.1029/2018GC007529\n\nPlease consult pyshtools  "
+        f"documentation at:\n"
+        f" {Cyan}https://pypi.org/project/pyshtools\n"
+        f"{Yellow}And installation instructions for CAP with pyshtools:\n"
+        f" {Cyan}https://amescap.readthedocs.io/en/latest/installation."
+        f"html#_spectral_analysis{Yellow}\n"
+        f"__________________{Nclr}\n\n"
     )
 
 def diurn_extract(VAR, N, tod, lon):

--- a/amescap/Spectral_utils.py
+++ b/amescap/Spectral_utils.py
@@ -545,3 +545,13 @@ def zonal_construct(COEFFS_flat, VAR_shape, btype=None, low_highcut=None):
         VAR[ii, :, :] = pyshtools.expand.MakeGridDH(COEFFS_flat[ii, :, :],
                                                   sampling = 2)
     return  VAR.reshape(VAR_shape)
+
+
+def init_shtools():
+    """
+    Check if pyshtools is available and return its availability status
+    
+    :return: True if pyshtools is available, False otherwise
+    :rtype: bool
+    """
+    return PYSHTOOLS_AVAILABLE

--- a/bin/MarsFiles.py
+++ b/bin/MarsFiles.py
@@ -339,7 +339,7 @@ parser.add_argument('-hps', '--high_pass_spatial', action=ExtAction,
     nargs='+', type=int,
     help=(
         f"{Red}"
-        f"REQUIRES SPECIAL INSTALL: See 'Spectral Analysis "
+        f"REQUIRES SPECIAL INSTALL:\nSee 'Spectral Analysis "
         f"Capabilities' in the installation instructions at \n"
         f"https://amescap.readthedocs.io/en/latest/installation.html"
         f"{Nclr}\n"
@@ -359,7 +359,7 @@ parser.add_argument('-lps', '--low_pass_spatial', action=ExtAction,
     nargs='+', type=int,
     help=(
         f"{Red}"
-        f"REQUIRES SPECIAL INSTALL: See 'Spectral Analysis "
+        f"REQUIRES SPECIAL INSTALL:\nSee 'Spectral Analysis "
         f"Capabilities' in the installation instructions at \n"
         f"https://amescap.readthedocs.io/en/latest/installation.html"
         f"{Nclr}\n"
@@ -379,7 +379,7 @@ parser.add_argument('-bps', '--band_pass_spatial', action=ExtAction,
     nargs='+', type=int,
     help=(
         f"{Red}"
-        f"REQUIRES SPECIAL INSTALL: See 'Spectral Analysis "
+        f"REQUIRES SPECIAL INSTALL:\nSee 'Spectral Analysis "
         f"Capabilities' in the installation instructions at \n"
         f"https://amescap.readthedocs.io/en/latest/installation.html"
         f"{Nclr}\n"

--- a/bin/MarsFiles.py
+++ b/bin/MarsFiles.py
@@ -21,6 +21,9 @@ and optionally accepts:
     * ``[-lpt, --low_pass_temporal]``     Temporal filter: low-pass
     * ``[-bpt, --band_pass_temporal]``    Temporal filter: band-pass
     * ``[-trend, --add_trend]``           Return amplitudes only (use with temporal filters)
+    * ``[-hps, --high_pass_spatial]``     Spatial filter: high-pass
+    * ``[-lps, --low_pass_spatial]``      Spatial filter: low-pass
+    * ``[-bps, --band_pass_spatial]``     Spatial filter: band-pass
     * ``[-tide, --tide_decomp]``          Extract diurnal tide and its harmonics
     * ``[-recon, --reconstruct]``         Reconstruct the first N harmonics
     * ``[-norm, --normalize]``            Provide ``-tide`` result in % amplitude
@@ -56,7 +59,6 @@ import warnings     # Suppress errors triggered by NaNs
 import re           # Regular expressions
 import numpy as np
 from netCDF4 import Dataset
-import tempfile     # Platform-independent temporary file creation
 
 # Load amesCAP modules
 from amescap.Ncdf_wrapper import (Ncdf, Fort)
@@ -65,7 +67,7 @@ from amescap.FV3_utils import (
 )
 from amescap.Script_utils import (
     find_tod_in_diurn, FV3_file_type, filter_vars, regrid_Ncfile,
-    get_longname_unit, check_bounds
+    get_longname_unit, extract_path_basename, check_bounds
 )
 
 # ------------------------------------------------------
@@ -129,7 +131,7 @@ import traceback
 
 def debug_wrapper(func):
     """
-    A decorator that wraps a function with error handling based on the
+    A decorator that wraps a function with error handling based on the 
     --debug flag.
     """
     @functools.wraps(func)
@@ -330,6 +332,67 @@ parser.add_argument('-bpt', '--band_pass_temporal', action=ExtAction,
     )
 )
 
+# Decomposition in zonal harmonics, disabled for initial CAP release:
+parser.add_argument('-hps', '--high_pass_spatial', action=ExtAction,
+    ext_content='_hps',
+    parser=parser,
+    nargs='+', type=int,
+    help=(
+        f"{Red}"
+        f"REQUIRES SPECIAL INSTALL: See 'Spectral Analysis "
+        f"Capabilities' in the installation instructions at \n"
+        f"https://amescap.readthedocs.io/en/latest/installation.html"
+        f"{Nclr}\n"
+        f"Spatial high-pass filtering: removes low-frequency noise. "
+        f"Only works with 'daily' files.\nRequires a cutoff frequency "
+        f"in Sols.\n"
+        f"{Yellow}Generates a new file ending in ``_hps.nc``\n"
+        f"{Green}Example:\n"
+        f"> MarsFiles 01336.atmos_daily.nc -hps 10 -add_trend\n"
+        f"{Nclr}\n\n"
+    )
+)
+
+parser.add_argument('-lps', '--low_pass_spatial', action=ExtAction,
+    ext_content='_lps',
+    parser=parser,
+    nargs='+', type=int,
+    help=(
+        f"{Red}"
+        f"REQUIRES SPECIAL INSTALL: See 'Spectral Analysis "
+        f"Capabilities' in the installation instructions at \n"
+        f"https://amescap.readthedocs.io/en/latest/installation.html"
+        f"{Nclr}\n"
+        f"Spatial low-pass filtering: removes high-frequency noise "
+        f"(smoothing).\nOnly works with 'daily' files. Requires a "
+        f"cutoff frequency in Sols.\n"
+        f"{Yellow}Generates a new file ending in ``_lps.nc``\n"
+        f"{Green}Example:\n"
+        f"> MarsFiles 01336.atmos_daily.nc -lps 20 -add_trend\n"
+        f"{Nclr}\n\n"
+    )
+)
+
+parser.add_argument('-bps', '--band_pass_spatial', action=ExtAction,
+    ext_content='_bps',
+    parser=parser,
+    nargs='+', type=int,
+    help=(
+        f"{Red}"
+        f"REQUIRES SPECIAL INSTALL: See 'Spectral Analysis "
+        f"Capabilities' in the installation instructions at \n"
+        f"https://amescap.readthedocs.io/en/latest/installation.html"
+        f"{Nclr}\n"
+        f"Spatial band-pass filtering: filters out frequencies "
+        f"specified by user.\nOnly works with 'daily' files. Requires a "
+        f"cutoff frequency in Sols.\nData detrended before filtering.\n"
+        f"{Yellow}Generates a new file ending in ``_bps.nc``\n"
+        f"{Green}Example:\n"
+        f"> MarsFiles 01336.atmos_daily.nc -bps 10 20 -add_trend\n"
+        f"{Nclr}\n\n"
+    )
+)
+
 parser.add_argument('-tide', '--tide_decomp', action=ExtAction,
     ext_content='_tide_decomp',
     parser=parser,
@@ -492,7 +555,7 @@ debug = args.debug
 
 if args.input_file:
     for file in args.input_file:
-        if not (re.search(".nc", file.name) or
+        if not (re.search(".nc", file.name) or 
                 re.search("fort.11", file.name)):
             parser.error(
                 f"{Red}{file.name} is not a netCDF or fort.11 file{Nclr}"
@@ -524,16 +587,17 @@ if args.reconstruct and not args.tide_decomp:
 all_args = [args.bin_files, args.concatenate, args.split, args.time_shift,
             args.bin_average, args.bin_diurn, args.high_pass_temporal,
             args.low_pass_temporal, args.band_pass_temporal,
-            args.tide_decomp, args.normalize,
+            args.high_pass_spatial, args.low_pass_spatial,
+            args.band_pass_spatial, args.tide_decomp, args.normalize,
             args.regrid_XY_to_match, args.zonal_average]
 
-if (all(v is None or v is False for v in all_args)
+if (all(v is None or v is False for v in all_args) 
     and args.include is not None):
     parser.error(f"{Red}[-incl --include] must be used with another "
                  f"argument{Nclr}")
     exit()
 
-if (all(v is None or v is False for v in all_args) and
+if (all(v is None or v is False for v in all_args) and 
     args.extension is not None):
     parser.error(f"{Red}[-ext --extension] must be used with another "
                  f"argument{Nclr}")
@@ -555,6 +619,9 @@ out_ext = (f"{args.time_shift_ext}"
             f"{args.low_pass_temporal_ext}"
             f"{args.band_pass_temporal_ext}"
             f"{args.add_trend_ext}"
+            f"{args.high_pass_spatial_ext}"
+            f"{args.low_pass_spatial_ext}"
+            f"{args.band_pass_spatial_ext}"
             f"{args.tide_decomp_ext}"
             f"{args.reconstruct_ext}"
             f"{args.normalize_ext}"
@@ -586,11 +653,11 @@ def concatenate_files(file_list, full_file_list):
     # effect as combining files
     num_files = len(full_file_list)
     if (file_list[0][5:] == ".fixed.nc" and num_files >= 2):
+        rm_cmd = "rm -f "
         for i in range(1, num_files):
-            try:
-                os.remove(full_file_list[i])
-            except OSError as e:
-                print(f"{Yellow}Warning: Could not remove {full_file_list[i]}: {e}{Nclr}")
+            # 1-N files ensures file number 0 is preserved
+            rm_cmd += f" {full_file_list[i]}"
+        subprocess.run(rm_cmd, universal_newlines = True, shell = True)
         print(f"{Cyan}Cleaned all but {file_list[0]}{Nclr}")
         exit()
 
@@ -608,8 +675,7 @@ def concatenate_files(file_list, full_file_list):
         exclude_list = []
 
     # Create a temporary file ending in _tmp.nc to work in
-    file_base = os.path.splitext(full_file_list[0])[0]
-    tmp_file = f"{file_base}_tmp.nc"
+    tmp_file = f"{full_file_list[0][:-3]}_tmp.nc"
     Log = Ncdf(tmp_file, "Merged file")
     Log.merge_files_from_list(full_file_list, exclude_var=exclude_list)
     Log.close()
@@ -619,8 +685,7 @@ def concatenate_files(file_list, full_file_list):
     # First, rename temporary file for the final merged file
     #   For Legacy netCDF files, rename using initial and end Ls
     #   For MGCM netCDF files, rename to the first file in the list
-    filename_base = os.path.basename(file_list[0])
-    if filename_base[:12] == "LegacyGCM_Ls":
+    if file_list[0][:12] == "LegacyGCM_Ls":
         ls_ini = file_list[0][12:15]
         ls_end = file_list[-1][18:21]
         merged_file = f"LegacyGCM_Ls{ls_ini}_Ls{ls_end}.nc"
@@ -629,20 +694,13 @@ def concatenate_files(file_list, full_file_list):
 
     # Delete the files that were concatenated.
     # Apply the new name created above
+    rm_cmd = "rm -f "
     for file in full_file_list:
-        try:
-            os.remove(file)
-        except OSError as e:
-            print(f"{Yellow}Warning: Could not remove {file}: {e}{Nclr}")
+        rm_cmd += f" {file}"
 
-    try:
-        os.rename(tmp_file, merged_file)
-    except OSError as e:
-        print(f"{Red}Error: Could not rename {tmp_file} to {merged_file}: {e}{Nclr}")
-        # Fallback option using shutil for cross-device moves
-        import shutil
-        shutil.move(tmp_file, merged_file)
-
+    cmd_txt = f"mv {tmp_file} {merged_file}"
+    subprocess.run(rm_cmd, universal_newlines = True, shell = True)
+    subprocess.run(cmd_txt, universal_newlines = True, shell = True)
     print(f"{Cyan}{merged_file} was created from a merge{Nclr}")
 
     return
@@ -672,23 +730,14 @@ def split_files(file_list, split_dim):
             )
         exit()
 
-    # Use os.path.join for platform-independent path handling
-    for file in file_list:
-        # Get the file name from the file object
-        if hasattr(file, 'name'):
-            input_file_name = file.name  # Get the name attribute of the file object
-        else:
-            input_file_name = file  # In case it's already a string
+    # Add path unless full path is provided
+    if not ("/" in file_list[0]):
+        input_file_name = f"{data_dir}/{file_list[0]}"
+    else:
+        input_file_name = file_list[0]
+    original_date = (input_file_name.split('.')[0]).split('/')[-1]
 
-    print(f"{Yellow}split input_file_name = {input_file_name}{Nclr}\n\n")
-
-    file_base = os.path.splitext(input_file_name)[0]
-    output_file_name = f"{file_base}{out_ext}.nc"
-    print(f"{Cyan}split output_file_name = {output_file_name}{Nclr}")
-
-    original_date = os.path.basename(os.path.splitext(input_file_name)[0])
-
-    fNcdf = Dataset(str(input_file_name), 'r', format='NETCDF4_CLASSIC')
+    fNcdf = Dataset(input_file_name, 'r', format='NETCDF4_CLASSIC')
     var_list = filter_vars(fNcdf, args.include)
 
     # Get file type (diurn, average, daily, etc.)
@@ -713,19 +762,19 @@ def split_files(file_list, split_dim):
     if f_type == 'diurn':
         if split_dim == 'areo':
             # size areo = (time, tod, scalar_axis)
-            reducing_dim = np.squeeze(fNcdf.variables[split_dim][:, 0, :])
+            reducing_dim = np.squeeze(fNcdf.variables['areo'][:, 0, :])
         else:
-            reducing_dim = np.squeeze(fNcdf.variables[split_dim][:])
+            reducing_dim = np.squeeze(fNcdf.variables[split_dim][:, 0])
     else:
         if split_dim == 'areo':
             # size areo = (time, scalar_axis)
-            reducing_dim = np.squeeze(fNcdf.variables[split_dim][:])
+            reducing_dim = np.squeeze(fNcdf.variables['areo'][:])
         else:
             reducing_dim = np.squeeze(fNcdf.variables[split_dim][:])
 
     if split_dim == 'areo':
         print(f"\n{Yellow}Areo MOD(360):\n{reducing_dim%360.}\n")
-
+    
     print(f"\n{Yellow}All values in dimension:\n{reducing_dim}\n")
 
     dx = np.abs(reducing_dim[1] - reducing_dim[0])
@@ -748,12 +797,12 @@ def split_files(file_list, split_dim):
         check_bounds(bounds, reducing_dim[0], reducing_dim[-1], dx)
         if ((split_dim == 'lon') & (bounds[1] < bounds[0])):
             indices = np.where(
-                (reducing_dim <= bounds[1]) |
+                (reducing_dim <= bounds[1]) | 
                 (reducing_dim >= bounds[0])
                 )[0]
         else:
             indices = np.where(
-                (reducing_dim >= bounds[0]) &
+                (reducing_dim >= bounds[0]) & 
                 (reducing_dim <= bounds[1])
                 )[0]
         dim_out = reducing_dim[indices]
@@ -761,7 +810,7 @@ def split_files(file_list, split_dim):
             f"Requested range = {bounds_in[0]} - {bounds_in[1]}\n"
             f"Corresponding values = {dim_out}\n"
             )
-
+        
         if len(indices) == 0:
             print(
                 f"{Red}Warning, no values were found in the range {split_dim} "
@@ -774,65 +823,92 @@ def split_files(file_list, split_dim):
         time_dim = (np.squeeze(fNcdf.variables['time'][:]))[indices]
         print(f"time_dim = {time_dim}")
 
-        # If time_dim is an array with multiple values, use the first one for naming
-        if hasattr(time_dim, '__len__') and len(time_dim) > 1:
-            time_value = time_dim[0]  # Use the first time value for the filename
-        else:
-            time_value = time_dim  # Use as is if it's a scalar
-
-    # For maintaining the 00000.atmos_average.nc format:
-    base_path = os.path.dirname(input_file_name)
-    file_name = os.path.basename(input_file_name)
-    # Split at the first dot to preserve the numeric prefix
-    file_date, file_base = file_name.split('.', 1)
+    fpath, fname = extract_path_basename(input_file_name)
     if split_dim == 'time':
         if len(np.atleast_1d(bounds)) < 2:
-            out_name = (f"{int(time_value):05d}.{file_base}_nearest_sol{int(bounds_in[0]):03d}.nc")
+            output_file_name = (
+                f"{fpath}/{int(time_dim):05d}{fname[5:-3]}_nearest_sol"
+                f"{int(bounds_in[0]):03d}.nc"
+                )
         else:
-            out_name = (f"{int(time_value):05d}.{file_base}_sol{int(bounds_in[0]):05d}_{int(bounds_in[1]):05d}.nc")
+            output_file_name = (
+                f"{fpath}/{int(time_dim[0]):05d}{fname[5:-3]}_sol"
+                f"{int(bounds_in[0]):05d}_{int(bounds_in[1]):05d}.nc"
+                )
     elif split_dim =='areo':
         if len(np.atleast_1d(bounds)) < 2:
-            out_name = (f"{int(time_value):05d}.{file_base}_nearest_Ls{int(bounds_in[0]):03d}.nc")
+            output_file_name = (
+                f"{fpath}/{int(time_dim):05d}{fname[5:-3]}_nearest_Ls"
+                f"{int(bounds_in[0]):03d}.nc"
+                )
         else:
-            out_name = (f"{int(time_value):05d}.{file_base}_Ls{int(bounds_in[0]):03d}_{int(bounds_in[1]):03d}.nc")
+            output_file_name = (f"{fpath}/{int(time_dim[0]):05d}{fname[5:-3]}_"
+                                f"Ls{int(bounds_in[0]):03d}_{int(bounds_in[1]):03d}.nc")
         split_dim = 'time'
     elif split_dim == 'lat':
-        new_bounds = [f"{abs(int(b))}S" if b < 0
-                      else f"{int(b)}N" for b in bounds]
+        new_bounds = [
+            f"{abs(int(b))}S" if b < 0 
+            else f"{int(b)}N" 
+            for b in bounds
+            ]
         if len(np.atleast_1d(bounds)) < 2:
-            out_name = (f"{original_date}.{file_base}_nearest_{split_dim}_{new_bounds[0]}.nc")
+            output_file_name = (
+                f"{fpath}/{original_date}{fname[5:-3]}_nearest_{split_dim}_"
+                f"{new_bounds[0]}.nc"
+                )
         else:
             print(f"{Yellow}bounds = {bounds[0]} {bounds[1]}")
             print(f"{Yellow}new_bounds = {new_bounds[0]} {new_bounds[1]}")
-            out_name = (f"{original_date}.{file_base}_{split_dim}_{new_bounds[0]}_{new_bounds[1]}.nc")
+            output_file_name = (
+                f"{fpath}/{original_date}{fname[5:-3]}_{split_dim}_"
+                f"{new_bounds[0]}_{new_bounds[1]}.nc"
+                )
     elif split_dim == interp_type:
         if interp_type == 'pfull':
-            new_bounds = [f"{abs(int(b*100))}Pa" if b < 1
-                          else f"{int(b)}{unt_txt} " for b in bounds]
+            new_bounds = [
+                f"{abs(int(b*100))}Pa" if b < 1 
+                else f"{int(b)}{unt_txt} "
+                for b in bounds
+                ]
         elif interp_type == 'pstd':
-            new_bounds = [f"{abs(int(b*100))}hPa" if b < 1
-                          else f"{int(b)}{unt_txt}" for b in bounds]
+            new_bounds = [
+                f"{abs(int(b*100))}hPa" if b < 1 
+                else f"{int(b)}{unt_txt}"
+                for b in bounds
+                ]
         else:
             new_bounds = [f"{int(b)}{unt_txt}" for b in bounds]
-
+            
         if len(np.atleast_1d(bounds)) < 2:
             print(f"{Yellow}bounds = {bounds[0]}")
             print(f"{Yellow}new_bounds = {new_bounds[0]}")
-            out_name = (f"{original_date}.{file_base}_{split_dim}_nearest_{new_bounds[0]}.nc")
+            output_file_name = (
+                f"{fpath}/{original_date}{fname[5:-3]}_nearest_"
+                f"{new_bounds[0]}.nc"
+                )
         else:
             print(f"{Yellow}bounds = {bounds[0]} {bounds[1]}")
             print(f"{Yellow}new_bounds = {new_bounds[0]} {new_bounds[1]}")
-            out_name = (f"{original_date}.{file_base}_{split_dim}_{new_bounds[0]}_{new_bounds[1]}.nc")
+            output_file_name = (
+                f"{fpath}/{original_date}{fname[5:-3]}_{new_bounds[0]}_"
+                f"{new_bounds[1]}.nc"
+                )
     else:
         if len(np.atleast_1d(bounds)) < 2:
-            out_name = (f"{original_date}.{file_base}_nearest_{split_dim}_{int(bounds[0]):03d}.nc")
+            output_file_name = (
+                f"{fpath}/{original_date}{fname[5:-3]}_nearest_{split_dim}_"
+                f"{int(bounds[0]):03d}.nc"
+                )
         else:
-            out_name = (f"{original_date}.{file_base}_{split_dim}_{int(bounds[0]):03d}_{int(bounds[1]):03d}.nc")
+            output_file_name = (
+                f"{fpath}/{original_date}{fname[5:-3]}_{split_dim}_"
+                f"{int(bounds[0]):03d}_{int(bounds[1]):03d}.nc"
+                )
 
     # Append extension, if any:
-    output_file_name = os.path.join(base_path, out_name)
-    print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
+    output_file_name = (f"{output_file_name[:-3]}{out_ext}.nc")
 
+    print(f"{Cyan}new filename = {output_file_name}")
     Log = Ncdf(output_file_name)
 
     Log.copy_all_dims_from_Ncfile(fNcdf, exclude_dim=[split_dim])
@@ -905,10 +981,10 @@ def split_files(file_list, split_dim):
                 var_out = varNcf[:, indices, :, :]
             longname_txt, units_txt = get_longname_unit(fNcdf, ivar)
             Log.log_variable(
-                ivar,
-                var_out,
+                ivar, 
+                var_out, 
                 varNcf.dimensions,
-                longname_txt,
+                longname_txt, 
                 units_txt
                 )
         else:
@@ -947,65 +1023,62 @@ def process_time_shift(file_list):
         target_list = np.fromstring(args.time_shift, dtype=float, sep=" ")
 
     for file in file_list:
-        # Get the file name from the file object
-        if hasattr(file, 'name'):
-            input_file_name = file.name  # Get the name attribute of the file object
+        # Add path unless full path is provided
+        if not ("/" in file):
+            input_file_name = f"{data_dir}/{file}"
         else:
-            input_file_name = file  # In case it's already a string
+            input_file_name = file
+        output_file_name = (f"{input_file_name[:-3]}{out_ext}.nc")
 
-        file_base = os.path.splitext(input_file_name)[0]
-        output_file_name = f"{file_base}{out_ext}.nc"
-        print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
-
-        input_file_diurn = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+        fdiurn = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
         # Define a netcdf object from the netcdf wrapper module
-        output_file = Ncdf(output_file_name)
+        fnew = Ncdf(output_file_name)
         # Copy some dimensions from the old file to the new file
-        output_file.copy_all_dims_from_Ncfile(input_file_diurn)
+        fnew.copy_all_dims_from_Ncfile(fdiurn)
 
         # Find the "time of day" variable name
-        tod_name_in = find_tod_in_diurn(input_file_diurn)
-        _, zaxis = FV3_file_type(input_file_diurn)
+        tod_name_in = find_tod_in_diurn(fdiurn)
+        _, zaxis = FV3_file_type(fdiurn)
 
         # Copy some variables from the old file to the new file
-        output_file.copy_Ncaxis_with_content(input_file_diurn.variables["lon"])
-        output_file.copy_Ncaxis_with_content(input_file_diurn.variables["lat"])
-        output_file.copy_Ncaxis_with_content(input_file_diurn.variables["time"])
+        fnew.copy_Ncaxis_with_content(fdiurn.variables["lon"])
+        fnew.copy_Ncaxis_with_content(fdiurn.variables["lat"])
+        fnew.copy_Ncaxis_with_content(fdiurn.variables["time"])
         try:
-            output_file.copy_Ncaxis_with_content(input_file_diurn.variables["scalar_axis"])
+            fnew.copy_Ncaxis_with_content(fdiurn.variables["scalar_axis"])
         except:
             print(f'{Red}Could not find scalar axis')
 
         # Only create a vertical axis if orig. file has 3D fields
-        if zaxis in input_file_diurn.dimensions.keys():
-            output_file.copy_Ncaxis_with_content(input_file_diurn.variables[zaxis])
+        if zaxis in fdiurn.dimensions.keys():
+            fnew.copy_Ncaxis_with_content(fdiurn.variables[zaxis])
 
         # Take care of TOD dimension in new file
-        tod_orig = np.array(input_file_diurn.variables[tod_name_in][:])
+        tod_orig = np.array(fdiurn.variables[tod_name_in])
 
         if target_list is None:
             # If user does not specify which TOD(s) to do, do all 24
             tod_name_out = tod_name_in
-            output_file.copy_Ncaxis_with_content(input_file_diurn.variables[tod_name_in])
-
+            fnew.copy_Ncaxis_with_content(fdiurn.variables[tod_name_in])
+            
             # Only copy "areo" if it exists in the original file
-            if "areo" in input_file_diurn.variables.keys():
-                output_file.copy_Ncvar(input_file_diurn.variables["areo"])
+            if "areo" in fdiurn.variables.keys():
+                fnew.copy_Ncvar(fdiurn.variables["areo"])
         else:
             # If user requests specific local times, update the old
             # axis as necessary
             tod_name_out = f"time_of_day_{(len(target_list)):02}"
-            output_file.add_dim_with_content(
-                tod_name_out,
+            fnew.add_dim_with_content(
+                tod_name_out, 
                 target_list,
                 longname_txt = "time of day",
                 units_txt = ("[hours since 0000-00-00 00:00:00]"),
                 cart_txt = ""
                 )
-
+            
             # Create areo variable with the new size
-            areo_shape = input_file_diurn.variables["areo"].shape
-            areo_dims = input_file_diurn.variables["areo"].dimensions
+            areo_shape = fdiurn.variables["areo"].shape
+            areo_dims = fdiurn.variables["areo"].dimensions
 
             # Update shape with new time_of_day
             areo_shape = (areo_shape[0], len(target_list), areo_shape[2])
@@ -1017,26 +1090,26 @@ def process_time_shift(file_list):
                 # For new target_list, e.g [3,15]
                 # Get the closest "time_of_day" index
                 j = np.argmin(np.abs(target_list[i] - tod_orig))
-                areo_out[:, i, 0] = input_file_diurn.variables["areo"][:, j, 0]
+                areo_out[:, i, 0] = fdiurn.variables["areo"][:, j, 0]
 
-            output_file.add_dim_with_content(
-                dimension_name = "scalar_axis",
-                DATAin = [0],
+            fnew.add_dim_with_content(
+                dimension_name = "scalar_axis", 
+                DATAin = [0], 
                 longname_txt = "none",
                 units_txt = "none"
                 )
-            output_file.log_variable("areo", areo_out, areo_dims, "areo", "degrees")
+            fnew.log_variable("areo", areo_out, areo_dims, "areo", "degrees")
 
         # Read in 4D field(s) and do the time shift. Exclude vars
         # not listed after --include in var_list
-        lons = np.array(input_file_diurn.variables["lon"][:])
-        var_list = filter_vars(input_file_diurn, args.include)
+        lons = np.array(fdiurn.variables["lon"])
+        var_list = filter_vars(fdiurn, args.include)
 
         for var in var_list:
             print(f"{Cyan}Processing: {var}...{Nclr}")
-            value = input_file_diurn.variables[var][:]
-            dims = input_file_diurn.variables[var].dimensions
-            longname_txt, units_txt = get_longname_unit(input_file_diurn, var)
+            value = fdiurn.variables[var][:]
+            dims = fdiurn.variables[var].dimensions
+            longname_txt, units_txt = get_longname_unit(fdiurn, var)
 
             if (len(dims) >= 4):
                 y = dims.index("lat")
@@ -1048,17 +1121,17 @@ def process_time_shift(file_list):
                 # time, tod, lat, lon
                 var_val_tmp = np.transpose(value, (x, y, t, tod))
                 var_val_T = time_shift_calc(
-                    var_in = var_val_tmp,
-                    lon = lons,
-                    tod = tod_orig,
-                    target_times = target_list
+                    var_val_tmp, 
+                    lons, 
+                    tod_orig,
+                    timex = target_list
                     )
                 var_out = np.transpose(var_val_T, (2, 3, 1, 0))
-                output_file.log_variable(
-                    var,
+                fnew.log_variable(
+                    var, 
                     var_out,
                     ["time", tod_name_out, "lat", "lon"],
-                    longname_txt,
+                    longname_txt, 
                     units_txt
                     )
             if (len(dims) == 5):
@@ -1066,21 +1139,21 @@ def process_time_shift(file_list):
                 z = dims.index(zaxis)
                 var_val_tmp = np.transpose(value, (x, y, z, t, tod))
                 var_val_T = time_shift_calc(
-                    var_in = var_val_tmp,
-                    lon = lons,
-                    tod = tod_orig,
-                    target_times = target_list
+                    var_val_tmp, 
+                    lons, 
+                    tod_orig,
+                    timex = target_list
                     )
                 var_out = np.transpose(var_val_T, (3, 4, 2, 1, 0))
-                output_file.log_variable(
-                    var,
+                fnew.log_variable(
+                    var, 
                     var_out,
                     ["time", tod_name_out, zaxis, "lat", "lon"],
                     longname_txt,
                     units_txt
                     )
-        output_file.close()
-        input_file_diurn.close()
+        fnew.close()
+        fdiurn.close()
     return
 
 # ------------------------------------------------------
@@ -1095,11 +1168,10 @@ def main():
     # Make a list of input files including the full path to the dir
     full_file_list = []
     for file in file_list:
-        if os.path.dirname(file) == "":
-            full_file_list = file
+        if not ("/" in file):
+            full_file_list.append(f"{data_dir}/{file}")
         else:
-            full_file_list = os.path.join(data_dir, file)
-        print(f"{Yellow}full_file_list = {full_file_list}{Nclr}\n\n")
+            full_file_list.append(f"{file}")
 
     if args.bin_files and args.concatenate:
         print(
@@ -1121,9 +1193,24 @@ def main():
                     f"'daily', or 'diurn'{Nclr}"
                     )
 
+        # lsmin = None
+        # lsmax = None
+
         if full_file_list[0][-3:] == ".nc":
             print("Processing Legacy MGCM netCDF files")
             for f in full_file_list:
+                # file_name = os.path.basename(f)
+                # ls_l = file_name[-12:-9]
+                # ls_r = file_name[-6:-3]
+
+                # if lsmin is None:
+                #     lsmin = ls_l
+                # else:
+                #     lsmin = str(min(int(lsmin), int(ls_l))).zfill(3)
+                # if lsmax is None:
+                #     lsmax = ls_r
+                # else:
+                #     lsmax = str(max(int(lsmax), int(ls_r))).zfill(3)
                 make_FV3_files(f, args.bin_files, True)
         elif "fort.11" in full_file_list[0]:
             print("Processing fort.11 files")
@@ -1158,28 +1245,25 @@ def main():
     #               Bin a daily file as an average file
     #                               Alex K.
     # ------------------------------------------------------------------
-    elif (args.bin_average and
+    elif (args.bin_average and 
           not args.bin_diurn):
 
         # Generate output file name
         bin_period = args.bin_average
         for file in file_list:
-            # Use os.path.join for platform-independent path handling
-            print(f"\n\n{Yellow}dir = {os.path.dirname(file)}{Nclr}")
-            if os.path.dirname(file) == "":
-                input_file_name = file
+            # Add path unless full path is provided
+            if not ("/" in file):
+                input_file_name = f"{data_dir}/{file}"
             else:
-                input_file_name = os.path.join(data_dir, file)
-            print(f"{Yellow}input_file_name = {input_file_name}{Nclr}\n\n")
+                input_file_name = file
 
-            file_base = os.path.splitext(input_file_name)[0]
-            output_file_name = f"{file_base}{out_ext}.nc"
-            print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
+            output_file_name = (f"{input_file_name[:-3]}"
+                        f"{out_ext}.nc")
 
-            input_file_daily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
-            var_list = filter_vars(input_file_daily, args.include)
+            fdaily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            var_list = filter_vars(fdaily, args.include)
 
-            time = input_file_daily.variables["time"][:]
+            time = fdaily.variables["time"][:]
 
             time_increment = time[1] - time[0]
             dt_per_day = int(np.round(1 / time_increment))
@@ -1202,16 +1286,16 @@ def main():
                     )
 
             # Define a netcdf object from the netcdf wrapper module
-            output_file = Ncdf(output_file_name)
+            fnew = Ncdf(output_file_name)
             # Copy all dimensions but time from the old file to the new file
-            output_file.copy_all_dims_from_Ncfile(input_file_daily, exclude_dim = ["time"])
+            fnew.copy_all_dims_from_Ncfile(fdaily, exclude_dim = ["time"])
 
             # Calculate and log the new time array
-            output_file.add_dimension("time", None)
+            fnew.add_dimension("time", None)
             time_out = daily_to_average(time[:], time_increment, bin_period)
-            output_file.log_axis1D(
-                "time",
-                time_out,
+            fnew.log_axis1D(
+                "time", 
+                time_out, 
                 "time",
                 longname_txt = "sol number",
                 units_txt = "days since 0000-00-00 00:00:00",
@@ -1220,32 +1304,32 @@ def main():
 
             # Loop over all variables in the file
             for ivar in var_list:
-                varNcf = input_file_daily.variables[ivar]
+                varNcf = fdaily.variables[ivar]
 
                 if "time" in varNcf.dimensions:
                     print(f"{Cyan}Processing: {ivar}{Nclr}")
                     var_out = daily_to_average(
-                        varNcf[:],
-                        time_increment,
+                        varNcf[:], 
+                        time_increment, 
                         bin_period
                         )
-                    longname_txt, units_txt = get_longname_unit(input_file_daily, ivar)
-                    output_file.log_variable(
-                        ivar,
-                        var_out,
+                    longname_txt, units_txt = get_longname_unit(fdaily, ivar)
+                    fnew.log_variable(
+                        ivar, 
+                        var_out, 
                         varNcf.dimensions,
-                        longname_txt,
+                        longname_txt, 
                         units_txt
                         )
                 else:
                     if ivar in ["pfull", "lat", "lon", "phalf", "pk",
                                 "bk", "pstd", "zstd", "zagl"]:
                         print(f"{Cyan}Copying axis: {ivar}{Nclr}")
-                        output_file.copy_Ncaxis_with_content(input_file_daily.variables[ivar])
+                        fnew.copy_Ncaxis_with_content(fdaily.variables[ivar])
                     else:
                         print(f"{Cyan}Copying variable: {ivar}{Nclr}")
-                        output_file.copy_Ncvar(input_file_daily.variables[ivar])
-            output_file.close()
+                        fnew.copy_Ncvar(fdaily.variables[ivar])
+            fnew.close()
 
     # ------------------------------------------------------------------
     #               Bin a daily file as a diurn file
@@ -1259,36 +1343,33 @@ def main():
             bin_period = args.bin_average
 
         for file in file_list:
-            # Use os.path.join for platform-independent path handling
-            print(f"\n\n{Yellow}dir = {os.path.dirname(file)}{Nclr}")
-            if os.path.dirname(file) == "":
-                input_file_name = file
+            # Add path unless full path is provided
+            if not ("/" in file):
+                input_file_name = f"{data_dir}/{file}"
             else:
-                input_file_name = os.path.join(data_dir, file)
-            print(f"{Yellow}input_file_name = {input_file_name}{Nclr}\n\n")
+                input_file_name = file
 
-            file_base = os.path.splitext(input_file_name)[0]
-            output_file_name = f"{file_base}{out_ext}.nc"
-            print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
+            output_file_name = (f"{input_file_name[:-3]}"
+                        f"{out_ext}.nc")
 
-            input_file_daily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
-            var_list = filter_vars(input_file_daily, args.include)
+            fdaily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            var_list = filter_vars(fdaily, args.include)
 
-            time = input_file_daily.variables["time"][:]
+            time = fdaily.variables["time"][:]
 
             time_increment = time[1] - time[0]
             dt_per_day = int(np.round(1/time_increment))
 
             # Define a netcdf object from the netcdf wrapper module
-            output_file = Ncdf(output_file_name)
+            fnew = Ncdf(output_file_name)
             # Copy all dimensions but "time" from the old file to the
             # new file
-            output_file.copy_all_dims_from_Ncfile(input_file_daily, exclude_dim = ["time"])
+            fnew.copy_all_dims_from_Ncfile(fdaily, exclude_dim = ["time"])
 
             # If no binning is requested, copy time axis as-is
-            output_file.add_dimension("time", None)
+            fnew.add_dimension("time", None)
             time_out = daily_to_average(time[:], time_increment, bin_period)
-            output_file.add_dim_with_content(
+            fnew.add_dim_with_content(
                 "time",
                 time_out,
                 longname_txt = "sol number",
@@ -1301,7 +1382,7 @@ def main():
             time_tod = np.squeeze(daily_to_diurn(time[0:dt_per_day],
                                                  time[0:dt_per_day]))
             tod = np.mod(time_tod*24, 24)
-            output_file.add_dim_with_content(
+            fnew.add_dim_with_content(
                 tod_name,
                 tod,
                 longname_txt = "time of day",
@@ -1311,7 +1392,7 @@ def main():
 
             # Loop over all variables in the file
             for ivar in var_list:
-                varNcf = input_file_daily.variables[ivar]
+                varNcf = fdaily.variables[ivar]
 
                 if "time" in varNcf.dimensions and ivar != "time":
                     # If time is the dimension (not just an array)
@@ -1322,11 +1403,10 @@ def main():
                     if bin_period != 1:
                         # dt is 1 sol between two diurn timesteps
                         var_out = daily_to_average(var_out, 1., bin_period)
-                    
-                    longname_txt, units_txt = get_longname_unit(input_file_daily, ivar)
-                    output_file.log_variable(
-                        ivar,
-                        var_out,
+                    longname_txt, units_txt = get_longname_unit(fdaily, ivar)
+                    fnew.log_variable(
+                        ivar, 
+                        var_out, 
                         dims_out,
                         longname_txt,
                         units_txt
@@ -1335,11 +1415,11 @@ def main():
                     if ivar in ["pfull", "lat", "lon", "phalf", "pk",
                                 "bk", "pstd", "zstd", "zagl"]:
                         print(f"{Cyan}Copying axis: {ivar}{Nclr}")
-                        output_file.copy_Ncaxis_with_content(input_file_daily.variables[ivar])
+                        fnew.copy_Ncaxis_with_content(fdaily.variables[ivar])
                     elif ivar != "time":
                         print(f"{Cyan}Copying variable: {ivar}{Nclr}")
-                        output_file.copy_Ncvar(input_file_daily.variables[ivar])
-            output_file.close()
+                        fnew.copy_Ncvar(fdaily.variables[ivar])
+            fnew.close()
 
     # ------------------------------------------------------------------
     #                       Temporal Filtering
@@ -1371,21 +1451,16 @@ def main():
                 exit()
 
         for file in file_list:
-            # Use os.path.join for platform-independent path handling
-            print(f"\n\n{Yellow}dir = {os.path.dirname(file)}{Nclr}")
-            if os.path.dirname(file) == "":
-                input_file_name = file
+            if not ("/" in file):
+                # Add path unless full path is provided
+                input_file_name = f"{data_dir}/{file}"
             else:
-                input_file_name = os.path.join(data_dir, file)
-            print(f"{Yellow}input_file_name = {input_file_name}{Nclr}\n\n")
+                input_file_name = file
 
-            file_base = os.path.splitext(input_file_name)[0]
-            output_file_name = f"{file_base}{out_ext}.nc"
-            print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
-
-            input_file_daily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
-            var_list = filter_vars(input_file_daily, args.include)
-            time = input_file_daily.variables["time"][:]
+            output_file_name = (f"{input_file_name[:-3]}{out_ext}.nc")
+            fdaily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            var_list = filter_vars(fdaily, args.include)
+            time = fdaily.variables["time"][:]
             dt = time[1] - time[0]
 
             # Check if the frequency domain is allowed
@@ -1397,34 +1472,34 @@ def main():
                 exit()
 
             # Define a netcdf object from the netcdf wrapper module
-            output_file = Ncdf(output_file_name)
+            fnew = Ncdf(output_file_name)
             # Copy all dimensions but time from the old file to the
             # new file
-            output_file.copy_all_dims_from_Ncfile(input_file_daily)
+            fnew.copy_all_dims_from_Ncfile(fdaily)
 
             if btype == "low":
-                output_file.add_constant(
-                    "sol_max",
+                fnew.add_constant(
+                    "sol_max", 
                     nsol,
                     "Low-pass filter cut-off period ",
                     "sol"
                     )
             elif btype == "high":
-                output_file.add_constant(
-                    "sol_min",
+                fnew.add_constant(
+                    "sol_min", 
                     nsol,
                     "High-pass filter cut-off period ",
                     "sol"
                     )
             elif btype == "band":
-                output_file.add_constant(
+                fnew.add_constant(
                     "sol_min",
                     nsol[0],
                     "High-pass filter low cut-off period ",
                     "sol"
                     )
-                output_file.add_constant(
-                    "sol_max",
+                fnew.add_constant(
+                    "sol_max", 
                     nsol[1],
                     "High-pass filter high cut-off period ",
                     "sol"
@@ -1433,46 +1508,203 @@ def main():
             if dt == 0:
                 print(f"{Red}***Error*** dt = 0, time dimension is not increasing")
                 exit()
-
-            frequency = 1 / (dt) # frequency in sol-1
+                
+            fs = 1/(dt) # frequency in sol-1
             if btype == "band":
                 # Flip the sols so that the low frequency comes first
-                low_highcut = 1 / nsol[::-1]
+                low_highcut = 1/nsol[::-1]
             else:
-                low_highcut = 1. / nsol
+                low_highcut = 1./nsol
 
             # Loop over all variables in the file
             for ivar in var_list:
-                varNcf = input_file_daily.variables[ivar]
+                varNcf = fdaily.variables[ivar]
+
                 if ("time" in varNcf.dimensions and
                     ivar not in ["time", "areo"]):
                     print(f"{Cyan}Processing: {ivar}{Nclr}")
                     var_out = zeroPhi_filter(
-                        varNcf[:],
-                        btype,
-                        low_highcut,
-                        frequency,
-                        axis = 0,
+                        varNcf[:], 
+                        btype, 
+                        low_highcut, 
+                        fs, 
+                        axis = 0, 
                         order = 4,
                         add_trend = args.add_trend
                         )
-                    longname_txt, units_txt = get_longname_unit(input_file_daily, ivar)
-                    output_file.log_variable(
-                        ivar,
-                        var_out,
+                    longname_txt, units_txt = get_longname_unit(fdaily, ivar)
+                    fnew.log_variable(
+                        ivar, 
+                        var_out, 
                         varNcf.dimensions,
-                        longname_txt,
+                        longname_txt, 
                         units_txt
                         )
                 else:
                     if ivar in ["pfull", "lat", "lon", "phalf", "pk",
                                 "bk", "pstd", "zstd", "zagl"]:
                         print(f"{Cyan}Copying axis: {ivar}{Nclr}")
-                        output_file.copy_Ncaxis_with_content(input_file_daily.variables[ivar])
+                        fnew.copy_Ncaxis_with_content(fdaily.variables[ivar])
                     else:
                         print(f"{Cyan}Copying variable: {ivar}{Nclr}")
-                        output_file.copy_Ncvar(input_file_daily.variables[ivar])
-            output_file.close()
+                        fnew.copy_Ncvar(fdaily.variables[ivar])
+            fnew.close()
+
+    # ------------------------------------------------------------------
+    #                      Zonal Decomposition Analysis
+    #                              Alex K.
+    # ------------------------------------------------------------------
+    elif (args.high_pass_spatial or
+          args.low_pass_spatial or
+          args.band_pass_spatial):
+        from amescap.Spectral_utils import (zonal_decomposition, 
+                                            zonal_construct, 
+                                            init_shtools)
+        # Load the module
+        init_shtools()
+        if args.high_pass_spatial:
+            btype = "high"
+            nk = np.asarray(args.high_pass_spatial).astype(int)
+            if len(np.atleast_1d(nk)) != 1:
+                print(f"{Red}***Error*** kmin accepts only one value")
+                exit()
+        if args.low_pass_spatial:
+            btype = "low"
+            nk = np.asarray(args.low_pass_spatial).astype(int)
+            if len(np.atleast_1d(nk)) != 1:
+                print(f"{Red}kmax accepts only one value")
+                exit()
+        if args.band_pass_spatial:
+            btype = "band"
+            nk = np.asarray(args.band_pass_spatial).astype(int)
+            if len(np.atleast_1d(nk)) != 2:
+                print(f"{Red}Requires two values: kmin kmax")
+                exit()
+
+        for file in file_list:
+            # Add path unless full path is provided
+            if not ("/" in file):
+                input_file_name = f"{data_dir}/{file}"
+            else:
+                input_file_name=file
+
+            output_file_name = (f"{input_file_name[:-3]}"
+                        f"{out_ext}.nc")
+
+            fname = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            # Get all variables
+            var_list = filter_vars(fname,args.include)
+            lon = fname.variables["lon"][:]
+            lat = fname.variables["lat"][:]
+            LON, LAT = np.meshgrid(lon,lat)
+
+            dlat = lat[1] - lat[0]
+            dx = 2*np.pi*3400
+
+            # Check if the frequency domain is allowed and display some
+            # information
+            if any(nn > len(lat)/2 for nn in nk):
+                print(
+                    f"{Red}***Warning***  maximum wavenumber cut-off cannot "
+                    f"be larger than the Nyquist criteria of nlat/2 = "
+                    f"{len(lat)/2} sol{Nclr}"
+                    )
+            elif btype == "low":
+                L_max = (1./nk) * dx
+                print(
+                    f"{Yellow}Low pass filter, allowing only wavelength > "
+                    f"{L_max} km{Nclr}"
+                    )
+            elif btype == "high":
+                L_min = (1./nk) * dx
+                print(
+                    f"{Yellow}High pass filter, allowing only wavelength < "
+                    f"{L_min} km{Nclr}"
+                    )
+            elif btype == "band":
+                L_min = (1. / nk[1]) * dx
+                L_max = 1. / max(nk[0], 1.e-20) * dx
+                if L_max > 1.e20:
+                    L_max = np.inf
+                print(
+                    f"{Yellow}Band pass filter, allowing only {L_min} km < "
+                    f"wavelength < {L_max} km{Nclr}"
+                    )
+
+            # Define a netcdf object from the netcdf wrapper module
+            fnew = Ncdf(output_file_name)
+            # Copy all dimensions but "time" from old -> new file
+            fnew.copy_all_dims_from_Ncfile(fname)
+
+            if btype == "low":
+                fnew.add_constant(
+                    "kmax", 
+                    nk,
+                    "Low-pass filter zonal wavenumber ",
+                    "wavenumber"
+                    )
+            elif btype == "high":
+                fnew.add_constant(
+                    "kmin", 
+                    nk,
+                    "High-pass filter zonal wavenumber ",
+                    "wavenumber"
+                    )
+            elif btype == "band":
+                fnew.add_constant(
+                    "kmin", 
+                    nk[0],
+                    "Band-pass filter low zonal wavenumber ",
+                    "wavenumber"
+                    )
+                fnew.add_constant(
+                    "kmax", 
+                    nk[1],
+                    "Band-pass filter high zonal wavenumber ",
+                    "wavenumber"
+                    )
+            low_highcut = nk
+
+            for ivar in var_list:
+                # Loop over all variables in the file
+                varNcf = fname.variables[ivar]
+                longname_txt, units_txt = get_longname_unit(fname, ivar)
+                if ("lat" in varNcf.dimensions and
+                    "lon" in varNcf.dimensions):
+                    print(f"{Cyan}Processing: {ivar}...{Nclr}")
+                    # Step 1: Detrend the data
+                    TREND = get_trend_2D(varNcf[:], LON, LAT,  "wmean")
+                    # Step 2: Calculate spherical harmonic coeffs
+                    COEFF, PSD = zonal_decomposition(varNcf[:] - TREND)
+                    # Step 3: Recompose the variable out of the coeffs
+                    VAR_filtered = zonal_construct(
+                        COEFF, 
+                        varNcf[:].shape,
+                        btype = btype,
+                        low_highcut = low_highcut
+                        )
+                    #Step 4: Add the trend, if requested
+                    if args.add_trend:
+                        var_out = VAR_filtered
+                    else:
+                        var_out = VAR_filtered + TREND
+
+                    fnew.log_variable(
+                        ivar, 
+                        var_out, 
+                        varNcf.dimensions,
+                        longname_txt, 
+                        units_txt
+                        )
+                else:
+                    if  ivar in ["pfull", "lat", "lon", "phalf", "pk", "bk",
+                                 "pstd", "zstd", "zagl", "time"]:
+                        print(f"{Cyan}Copying axis: {ivar}...{Nclr}")
+                        fnew.copy_Ncaxis_with_content(fname.variables[ivar])
+                    else:
+                        print(f"{Cyan}Copying variable: {ivar}...{Nclr}")
+                        fnew.copy_Ncvar(fname.variables[ivar])
+            fnew.close()
 
     # ------------------------------------------------------------------
     #                           Tidal Analysis
@@ -1486,50 +1718,46 @@ def main():
             exit()
 
         for file in file_list:
-            # Use os.path.join for platform-independent path handling
-            print(f"\n\n{Yellow}dir = {os.path.dirname(file)}{Nclr}")
-            if os.path.dirname(file) == "":
-                input_file_name = file
+            # Add path unless full path is provided
+            if not ("/" in file):
+                input_file_name = f"{data_dir}/{file}"
             else:
-                input_file_name = os.path.join(data_dir, file)
-            print(f"{Yellow}input_file_name = {input_file_name}{Nclr}\n\n")
+                input_file_name = file
 
-            file_base = os.path.splitext(input_file_name)[0]
-            output_file_name = f"{file_base}{out_ext}.nc"
-            print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
+            output_file_name = (f"{input_file_name[:-3]}{out_ext}.nc")
 
-            input_file_diurn = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            fdiurn = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
 
-            var_list = filter_vars(input_file_diurn, args.include)
+            var_list = filter_vars(fdiurn, args.include)
 
             # Find time_of_day variable name
-            tod_name = find_tod_in_diurn(input_file_diurn)
+            tod_name = find_tod_in_diurn(fdiurn)
 
-            target_tod = input_file_diurn.variables[tod_name][:]
-            lon = input_file_diurn.variables["lon"][:]
-            areo = input_file_diurn.variables["areo"][:]
+            target_tod = fdiurn.variables[tod_name][:]
+            lon = fdiurn.variables["lon"][:]
+            areo = fdiurn.variables["areo"][:]
 
             # Define a netcdf object from the netcdf wrapper module
-            output_file = Ncdf(output_file_name)
+            fnew = Ncdf(output_file_name)
             # Copy all dims but time_of_day from the old file to the
             # new file
 
             # Harmonics to reconstruct the signal. We use the original
             # time_of_day array.
             if args.reconstruct:
-                output_file.copy_all_dims_from_Ncfile(input_file_diurn)
+                fnew.copy_all_dims_from_Ncfile(fdiurn)
                 # Copy time_of_day axis from initial files
-                output_file.copy_Ncaxis_with_content(input_file_diurn.variables[tod_name])
+                fnew.copy_Ncaxis_with_content(fdiurn.variables[tod_name])
 
             else:
-                output_file.copy_all_dims_from_Ncfile(
-                    input_file_diurn, exclude_dim = [tod_name]
+                fnew.copy_all_dims_from_Ncfile(
+                    fdiurn, exclude_dim = [tod_name]
                     )
                 # Create new dimension holding the harmonics. We reuse
                 # the time_of_day name to facilitate. Compatible with
                 # other routines, but keep in mind this is the harmonic
                 # number
-                output_file.add_dim_with_content(
+                fnew.add_dim_with_content(
                     dimension_name = f"time_of_day_{N}",
                     DATAin = np.arange(1, N+1),
                     longname_txt = "tidal harmonics",
@@ -1539,9 +1767,10 @@ def main():
 
             # Loop over all variables in the file
             for ivar in var_list:
-                varNcf = input_file_diurn.variables[ivar]
+                varNcf = fdiurn.variables[ivar]
                 varIN = varNcf[:]
-                longname_txt, units_txt = get_longname_unit(input_file_diurn, ivar)
+                longname_txt, units_txt = get_longname_unit(fdiurn, ivar)
+                var_unit = getattr(varNcf, "units", "")
 
                 if (tod_name in varNcf.dimensions and
                     ivar not in [tod_name, "areo"] and
@@ -1554,24 +1783,25 @@ def main():
                         # time_of_day dimension
                         norm = np.mean(varIN, axis = 1)[:, np.newaxis, ...]
                         varIN = 100*(varIN-norm)/norm
-                        units_txt = f"% of diurnal mean"
+                        #units_txt = f"% of diurnal mean"
+                        var_unit = f"% of diurnal mean"
 
                     amp, phas = diurn_extract(
-                        varIN.swapaxes(0, 1),
+                        varIN.swapaxes(0, 1), 
                         N,
-                        target_tod,
+                        target_tod, 
                         lon
                         )
                     if args.reconstruct:
                         VARN = reconstruct_diurn(
-                            amp,
-                            phas,
-                            target_tod,
+                            amp, 
+                            phas, 
+                            target_tod, 
                             lon,
                             sumList=[]
                             )
                         for nn in range(N):
-                            output_file.log_variable(
+                            fnew.log_variable(
                                 f"{ivar}_N{nn+1}",
                                 VARN[nn, ...].swapaxes(0, 1),
                                 varNcf.dimensions,
@@ -1583,15 +1813,15 @@ def main():
                         # Update the dimensions
                         new_dim = list(varNcf.dimensions)
                         new_dim[1] = f"time_of_day_{N}"
-                        output_file.log_variable(
-                            f"{ivar}_amp",
+                        fnew.log_variable(
+                            f"{ivar}_amp", 
                             amp.swapaxes(0,1),
                             new_dim,
                             f"tidal amplitude for {longname_txt}",
                             units_txt
                             )
-                        output_file.log_variable(
-                            f"{ivar}_phas",
+                        fnew.log_variable(
+                            f"{ivar}_phas", 
                             phas.swapaxes(0,1),
                             new_dim,
                             f"tidal phase for {longname_txt}",
@@ -1601,13 +1831,13 @@ def main():
                 elif  ivar in ["pfull", "lat", "lon", "phalf", "pk",
                                "bk", "pstd", "zstd", "zagl", "time"]:
                         print(f"{Cyan}Copying axis: {ivar}...{Nclr}")
-                        output_file.copy_Ncaxis_with_content(input_file_diurn.variables[ivar])
+                        fnew.copy_Ncaxis_with_content(fdiurn.variables[ivar])
                 elif  ivar in ["areo"]:
                         if args.reconstruct:
                             # time_of_day is the same size as the
                             # original file
                             print(f"{Cyan}Copying axis: {ivar}...{Nclr}")
-                            output_file.copy_Ncvar(input_file_diurn.variables["areo"])
+                            fnew.copy_Ncvar(fdiurn.variables["areo"])
                         else:
                             print(f"{Cyan}Processing: {ivar}...{Nclr}")
                             # Create areo variable reflecting the
@@ -1619,85 +1849,75 @@ def main():
                             # Update the dimensions
                             new_dim = list(varNcf.dimensions)
                             new_dim[1] = f"time_of_day_{N}"
-                            # output_file.log_variable(ivar, bareo_new, new_dim,
+                            # fnew.log_variable(ivar, bareo_new, new_dim,
                             # longname_txt, units_txt)
-                            output_file.log_variable(
-                                ivar,
-                                areo_new,
+                            fnew.log_variable(
+                                ivar, 
+                                areo_new, 
                                 new_dim,
-                                longname_txt,
-                                units_txt
+                                longname_txt, 
+                                var_unit
                                 )
-            output_file.close()
+            fnew.close()
 
     # ------------------------------------------------------------------
     #                           Regridding Routine
     #                                 Alex K.
     # ------------------------------------------------------------------
     elif args.regrid_XY_to_match:
-        target_file = args.regrid_XY_to_match[0]
-
-        if os.path.isabs(target_file):
-            # Use the path as-is if it's already an absolute path
-            target_file = os.path.normpath(target_file)
-        else:
-            # If it's a relative path, join with data_dir
-            target_file = os.path.normpath(os.path.join(data_dir, target_file))
-        print(f"{Yellow}target_file = {target_file}{Nclr}\n\n")
+        name_target = args.regrid_XY_to_match[0]
 
         # Add path unless full path is provided
-        target_file = Dataset(target_file, "r")
+        if not ("/" in name_target):
+            name_target = f"{data_dir}/{name_target}"
+        fNcdf_t = Dataset(name_target, "r")
 
         for file in file_list:
-            # Use os.path.join for platform-independent path handling
-            print(f"\n\n{Yellow}dir = {os.path.dirname(file)}{Nclr}")
-            if os.path.dirname(file) == "":
-                input_file_name = file
+            # Add path unless full path is provided
+            if not ("/" in file):
+                input_file_name = f"{data_dir}/{file}"
             else:
-                input_file_name = os.path.join(data_dir, file)
-            print(f"{Yellow}input_file_name = {input_file_name}{Nclr}\n\n")
+                input_file_name = file
 
-            file_base = os.path.splitext(input_file_name)[0]
-            output_file_name = f"{file_base}{out_ext}.nc"
-            print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
+            output_file_name = (f"{input_file_name[:-3]}{out_ext}.nc")
 
-            input_file = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            f_in = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
 
-            var_list = filter_vars(input_file, args.include)  # Get all variables
+            var_list = filter_vars(f_in, args.include)  # Get all variables
 
             # Define a netcdf object from the netcdf wrapper module
-            output_file = Ncdf(output_file_name)
+            fnew = Ncdf(output_file_name)
 
             # Copy all dims from the target file to the new file
-            output_file.copy_all_dims_from_Ncfile(target_file)
+            fnew.copy_all_dims_from_Ncfile(fNcdf_t)
 
             # Loop over all variables in the file
             print(var_list)
             for ivar in var_list:
-                varNcf = input_file.variables[ivar]
-                longname_txt, units_txt = get_longname_unit(input_file, ivar)
+                varNcf = f_in.variables[ivar]
+                longname_txt, units_txt = get_longname_unit(f_in, ivar)
 
                 if  ivar in ["pfull", "lat", "lon", "phalf", "pk",
                              "bk", "pstd", "zstd", "zagl", "time", "areo"]:
-                        if ivar in target_file.variables.keys():
+                        if ivar in fNcdf_t.variables.keys():
                             print(f"{Cyan}Copying axis: {ivar}...{Nclr}")
-                            output_file.copy_Ncaxis_with_content(
-                                target_file.variables[ivar]
+                            fnew.copy_Ncaxis_with_content(
+                                fNcdf_t.variables[ivar]
                                 )
                 elif varNcf.dimensions[-2:] == ("lat", "lon"):
                     # Ignore variables like time_bounds, scalar_axis
                     # or grid_xt_bnds...
                     print(f"{Cyan}Regridding: {ivar}...{Nclr}")
-                    var_OUT = regrid_Ncfile(varNcf, input_file, target_file)
-                    output_file.log_variable(
-                        ivar,
-                        var_OUT,
+                    var_OUT = regrid_Ncfile(varNcf, f_in, fNcdf_t)
+                    fnew.log_variable(
+                        ivar, 
+                        var_OUT, 
                         varNcf.dimensions,
-                        longname_txt,
+                        longname_txt, 
                         units_txt
                         )
-            output_file.close()
-            target_file.close()
+            fnew.close()
+            fNcdf_t.close()
 
     # ------------------------------------------------------------------
     #                           Zonal Averaging
@@ -1705,42 +1925,38 @@ def main():
     # ------------------------------------------------------------------
     elif args.zonal_average:
         for file in file_list:
-            # Use os.path.join for platform-independent path handling
-            print(f"\n\n{Yellow}dir = {os.path.dirname(file)}{Nclr}")
-            if os.path.dirname(file) == "":
-                input_file_name = file
+            if not ("/" in file):
+                # Add path unless full path is provided
+                input_file_name = f"{data_dir}/{file}"
             else:
-                input_file_name = os.path.join(data_dir, file)
-            print(f"{Yellow}input_file_name = {input_file_name}{Nclr}\n\n")
+                input_file_name = file
 
-            file_base = os.path.splitext(input_file_name)[0]
-            output_file_name = f"{file_base}{out_ext}.nc"
-            print(f"{Cyan}output_file_name = {output_file_name}{Nclr}")
+            output_file_name = (f"{input_file_name[:-3]}{out_ext}.nc")
 
-            input_file_daily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
-            var_list = filter_vars(input_file_daily, args.include) # Get all variables
+            fdaily = Dataset(input_file_name, "r", format="NETCDF4_CLASSIC")
+            var_list = filter_vars(fdaily, args.include) # Get all variables
 
-            lon_in = input_file_daily.variables["lon"][:]
+            lon_in = fdaily.variables["lon"][:]
 
             # Define a netcdf object from the netcdf wrapper module
-            output_file = Ncdf(output_file_name)
+            fnew = Ncdf(output_file_name)
             # Copy all dimensions but time from the old file to the
             # new file
-            output_file.copy_all_dims_from_Ncfile(input_file_daily, exclude_dim = ["lon"])
+            fnew.copy_all_dims_from_Ncfile(fdaily, exclude_dim = ["lon"])
 
             # Add a new dimension for the longitude, size = 1
-            output_file.add_dim_with_content(
-                "lon",
+            fnew.add_dim_with_content(
+                "lon", 
                 [lon_in.mean()],
                 longname_txt = "longitude",
-                units_txt = "degrees_E",
+                units_txt = "degrees_E", 
                 cart_txt = "X"
                 )
 
             # Loop over all variables in the file
             for ivar in var_list:
-                varNcf = input_file_daily.variables[ivar]
-                longname_txt,units_txt = get_longname_unit(input_file_daily,ivar)
+                varNcf = fdaily.variables[ivar]
+                longname_txt,units_txt = get_longname_unit(fdaily,ivar)
                 if ("lon" in varNcf.dimensions and
                     ivar not in ["lon", "grid_xt_bnds", "grid_yt_bnds"]):
                     print(f"{Cyan}Processing: {ivar}...{Nclr}")
@@ -1751,24 +1967,24 @@ def main():
                         var_out = np.nanmean(
                             varNcf[:], axis = -1
                             )[..., np.newaxis]
-                        output_file.log_variable(
-                            ivar,
-                            var_out,
+                        fnew.log_variable(
+                            ivar, 
+                            var_out, 
                             varNcf.dimensions,
-                            longname_txt,
+                            longname_txt, 
                             units_txt
                             )
                 else:
                     if ivar in ["pfull", "lat", "phalf", "pk", "bk", "pstd",
                                 "zstd", "zagl"]:
                         print(f"{Cyan}Copying axis: {ivar}{Nclr}{Nclr}")
-                        output_file.copy_Ncaxis_with_content(input_file_daily.variables[ivar])
+                        fnew.copy_Ncaxis_with_content(fdaily.variables[ivar])
                     elif ivar in ["grid_xt_bnds", "grid_yt_bnds", "lon"]:
                         pass
                     else:
                         print(f"{Cyan}Copying variable: {ivar}{Nclr}")
-                        output_file.copy_Ncvar(input_file_daily.variables[ivar])
-            output_file.close()
+                        fnew.copy_Ncvar(fdaily.variables[ivar])
+            fnew.close()
     else:
         print(
             f"{Red}Error: no action requested: use ``MarsFiles *nc "
@@ -1829,20 +2045,20 @@ def make_FV3_files(fpath, typelistfv3, renameFV3=True):
                 var = histfile.variables["longitude"]
                 npvar = var[:]
                 newf.add_dim_with_content(
-                    "lon",
-                    npvar,
+                    "lon", 
+                    npvar, 
                     "longitude",
-                    getattr(var, "units"),
+                    getattr(var, "units"), 
                     "X"
                     )
             elif dname == "nlat":
                 var = histfile.variables["latitude"]
                 npvar = var[:]
                 newf.add_dim_with_content(
-                    "lat",
-                    npvar,
+                    "lat", 
+                    npvar, 
                     "latitude",
-                    getattr(var, "units"),
+                    getattr(var, "units"), 
                     "Y"
                     )
 
@@ -1871,46 +2087,50 @@ def make_FV3_files(fpath, typelistfv3, renameFV3=True):
                     bk[z + 1] = sgm[2*z + 2]
                 phalf[:] = pk[:] + pref*bk[:] # [Pa]
 
+                # DEPRECATED:
+                # pfull[:] = (phalf[1:]-phalf[:num])/(np.log(phalf[1:])
+                #             - np.log(phalf[:num]))
+
                 # First layer:
                 if pk[0] == 0 and bk[0] == 0:
                     pfull[0] = 0.5*(phalf[0] + phalf[1])
                 else:
                     pfull[0] = (
-                        (phalf[1]-phalf[0])
+                        (phalf[1]-phalf[0]) 
                         / (np.log(phalf[1]) - np.log(phalf[0]))
                         )
                 # All other layers:
                 pfull[1:] = (
-                    (phalf[2:]-phalf[1:-1])
+                    (phalf[2:]-phalf[1:-1]) 
                     / (np.log(phalf[2:]) - np.log(phalf[1:-1]))
                     )
 
                 newf.add_dim_with_content(
-                    "pfull",
+                    "pfull", 
                     pfull,
-                    "ref full pressure level",
+                    "ref full pressure level", 
                     "Pa"
                     )
                 newf.add_dim_with_content(
-                    "phalf",
+                    "phalf", 
                     phalf,
-                    "ref half pressure level",
+                    "ref half pressure level", 
                     "Pa"
                     )
                 newf.log_axis1D(
-                    "pk",
-                    pk,
+                    "pk", 
+                    pk, 
                     ("phalf"),
                     longname_txt = ("pressure part of the hybrid coordinate"),
-                    units_txt = "Pa",
+                    units_txt = "Pa", 
                     cart_txt = ""
                     )
                 newf.log_axis1D(
-                    "bk",
-                    bk,
+                    "bk", 
+                    bk, 
                     ("phalf"),
                     longname_txt = ("sigma part of the hybrid coordinate"),
-                    units_txt = "Pa",
+                    units_txt = "Pa", 
                     cart_txt = ""
                     )
             else:
@@ -1932,30 +2152,24 @@ def make_FV3_files(fpath, typelistfv3, renameFV3=True):
         # Daily snapshot of the output
         newfname_daily = f"{fdate}.atmos_daily.nc"
         newfpath_daily = os.path.join(historyDir, newfname_daily)
-        newinput_file_daily = Ncdf(newfpath_daily)
-        proccess_file(newinput_file_daily, "daily")
-        do_avg_vars(histfile, newinput_file_daily, False, False)
-        newinput_file_daily.close()
+        newfdaily = Ncdf(newfpath_daily)
+        proccess_file(newfdaily, "daily")
+        do_avg_vars(histfile, newfdaily, False, False)
+        newfdaily.close()
 
     if "diurn" in typelistfv3:
         # 5-sol average over "time" only
         newfname_diurn = f"{fdate}.atmos_diurn.nc"
         newfpath_diurn = os.path.join(historyDir, newfname_diurn)
-        newinput_file_diurn = Ncdf(newfpath_diurn)
-        proccess_file(newinput_file_diurn, "diurn")
-        do_avg_vars(histfile, newinput_file_diurn, True, False)
-        newinput_file_diurn.close()
+        newfdiurn = Ncdf(newfpath_diurn)
+        proccess_file(newfdiurn, "diurn")
+        do_avg_vars(histfile, newfdiurn, True, False)
+        newfdiurn.close()
 
     if "fixed" in typelistfv3:
         # Copy Legacy.fixed to current directory
-        source_file = os.path.join(sys.prefix, "mars_data", "Legacy.fixed.nc")
-        fixed_file_name = f"{fdate}.fixed.nc"
-        import shutil
-        try:
-            shutil.copy2(source_file, fixed_file_name)
-            print(f"{Cyan}{os.path.join(os.getcwd(), fixed_file_name)} was copied locally{Nclr}")
-        except OSError as e:
-            print(f"{Red}Error copying {source_file} to {fixed_file_name}: {e}{Nclr}")
+        cmd_txt = f"cp {sys.prefix}/mars_data/Legacy.fixed.nc {fdate}.fixed.nc"
+        subprocess.run(cmd_txt, universal_newlines = True, shell = True)
         print(f"{os.getcwd()}/{fdate}.fixed.nc was copied locally")
 
 def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
@@ -2054,16 +2268,16 @@ def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
                     time0[:] = time0[:]*step + ls2sol_1year(ls_start)
 
                 newf.log_axis1D(
-                    "areo",
-                    varnew,
+                    "areo", 
+                    varnew, 
                     dims,
                     longname_txt = "solar longitude",
                     units_txt = "degree",
                     cart_txt = "T"
                     )
                 newf.log_axis1D(
-                    "time",
-                    time0,
+                    "time", 
+                    time0, 
                     dims,
                     longname_txt = "sol number",
                     units_txt = "days since 0000-00-00 00:00:00",
@@ -2078,7 +2292,7 @@ def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
                 varnew = np.mean(
                     npvar.reshape(
                         -1, bin_period, vshape[1], vshape[2], vshape[3]
-                        ),
+                        ), 
                     axis = 1
                     )
             if avgtod:
@@ -2093,8 +2307,8 @@ def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
             if vname2 == "ps":
                 varnew *= 100.
             newf.log_variable(
-                vname2,
-                varnew,
+                vname2, 
+                varnew, 
                 newdims,
                 longname_txt2,
                 units_txt2
@@ -2105,7 +2319,7 @@ def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
                 varnew = np.mean(
                     npvar.reshape(
                         -1, bin_period, vshape[1], vshape[2], vshape[3], vshape[4]
-                        ),
+                        ), 
                     axis = 1
                     )
             if avgtod:
@@ -2117,8 +2331,8 @@ def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
                 vname, longname_txt, units_txt
                 )
             newf.log_variable(
-                vname2,
-                varnew,
+                vname2, 
+                varnew, 
                 newdims,
                 longname_txt2,
                 units_txt2
@@ -2134,9 +2348,9 @@ def do_avg_vars(histfile, newf, avgtime, avgtod, bin_period=5):
                 # Every 1.5 hours, centered at half timestep
                 npvar = np.arange(0.75, 24, 1.5)
                 newf.log_variable(
-                    vname2,
-                    npvar,
-                    newdims,
+                    vname2, 
+                    npvar, 
+                    newdims, 
                     longname_txt2,
                     units_txt2
                     )
@@ -2255,12 +2469,11 @@ def replace_at_index(tuple_dims, idx, new_name):
 
     """
     if new_name is None:
-        return tuple_dims[:idx] + tuple_dims[idx + 1:]
+        return tuple_dims[:idx] + tuple_dims[idx+1:]
     else:
-        return tuple_dims[:idx] + (new_name,) + tuple_dims[idx + 1:]
-    
+        return tuple_dims[:idx] + (new_name,) + tuple_dims[idx+1:]
 
-def ls2sol_1year(Ls_deg, offset=True):
+def ls2sol_1year(Ls_deg, offset=True, round10=True):
     """
     Returns a sol number from the solar longitude.
 
@@ -2270,39 +2483,42 @@ def ls2sol_1year(Ls_deg, offset=True):
     :param offset: if True, force year to start at Ls 0
     :type offset: bool
 
-    :returns: ``sol_number`` the sol number
+    :param round10: if True, round to the nearest 10 sols
+    :type round10: bool
+
+    :returns: ``Ds`` the sol number
 
     ..note::
         For the moment, this is consistent with 0 <= Ls <= 359.99, but
         not for monotically increasing Ls.
 
     """
-    Ls_perihelion = 250.99 # Ls at perihelion
-    time_perihelion = 485.35 # Time (in sols) at perihelion
-    num_sols_yearly = 668.6 # Number of sols in 1 MY
-    e = 0.093379 # From MGCM's modules.f90
+    Ls_perihelion = 250.99    # Ls at perihelion
+    tperi = 485.35  # Time (in sols) at perihelion
+    Ns = 668.6      # Number of sols in 1 MY
+    e = 0.093379    # From MGCM: modules.f90
     nu = (Ls_deg - Ls_perihelion)*np.pi/180
     if nu == np.pi:
         nu = nu + 1e-10  # Adding epsilon of 10^-10
     E = 2 * np.arctan(np.tan(nu/2) * np.sqrt((1-e)/(1+e)))
     M = E - e*np.sin(E)
-    sol_number = M/(2*np.pi)*num_sols_yearly + time_perihelion
+    Ds = M/(2*np.pi)*Ns + tperi
 
     if offset:
         # Offset correction:
-        if len(np.atleast_1d(sol_number)) == 1:
-            # sol_number is a float
-            sol_number -= num_sols_yearly
-            if sol_number < 0:
-                sol_number += num_sols_yearly
+        if len(np.atleast_1d(Ds)) == 1:
+            # Ds is a float
+            Ds -= Ns
+            if Ds < 0:
+                Ds += Ns
         else:
-            # sol_number is an array
-            sol_number -= num_sols_yearly
-            sol_number[sol_number < 0] = sol_number[sol_number < 0] + num_sols_yearly
+            # Ds is an array
+            Ds -= Ns
+            Ds[Ds < 0] = Ds[Ds < 0] + Ns
     if round:
         # -1 means round to the nearest 10
-        sol_number = np.round(sol_number, -1)
-    return sol_number
+        Ds = np.round(Ds, -1)
+    return Ds
 
 # ------------------------------------------------------
 #                  END OF PROGRAM

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,9 @@ xarray==2023.5.0
 pyodbc==4.0.39
 setuptools==57.4.0
 pandas==2.0.3
-# pyshtools==4.13.1
+
+# Optional dependencies
+# pyshtools>=4.10.0  # For spectral analysis capabilities
 
 # Documentation dependencies
 sphinx==7.2.6

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,14 +3,26 @@
 Installation Instructions
 =========================
 
-*Last Updated: March 2025*
+*Last Updated: April 2025*
 
 Installing CAP is done on the command line via ``git clone``. Here, we provide instructions for installing on Windows using Cygwin or PowerShell and pip or conda, MacOS using pip or conda, and the NASA Advanced Supercomputing (NAS) system using pip.
 
 :ref:`MacOS Installation <mac_install>`
+
 :ref:`Windows Installation <windows_install>`
+
 :ref:`NAS Installation <nas_install>`
+
 :ref:`Spectral Analysis Capabilities <spectral_analysis>`
+
+
+If you are specifically seeking to use CAP's spatial filtering utilities (low-, high-, and band-pass spatial filtering, or zonal decomposition), please follow the instructions for :ref:`Spectral Analysis Capabilities <spectral_analysis>` below, as these functions require the ``pyshtools`` library for spherical harmonic transforms and other spectral analysis functions.
+
+.. note::
+
+   The AmesCAP package is designed to be installed in a virtual environment. This allows you to manage dependencies and avoid conflicts with other Python packages. We recommend using either `pip` or `conda` for package management.
+
+   If you are using a conda environment, the installation process is straightforward and handles all dependencies automatically. If you are using pip, you will need to install some dependencies manually.
 
 .. _mac_install:
 
@@ -74,6 +86,16 @@ Install CAP from the `NASA Planetary Science GitHub <https://github.com/NASA-Pla
 .. code-block:: bash
 
    pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git
+
+.. note::
+
+   You can install a specific branch of the AmesCAP repository by appending ``@branch_name`` to the URL. For example, to install the ``devel`` branch, use:
+
+   .. code-block:: bash
+
+      pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git@devel
+   
+   This is useful if you want to test new features or bug fixes that are not yet in the main branch.
 
 4. Copy the profile file to your home directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -221,6 +243,18 @@ Using **conda** with **Cygwin**:
    # The same command works in both PowerShell and Cygwin
    pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git
 
+
+.. note::
+
+   You can install a specific branch of the AmesCAP repository by appending ``@branch_name`` to the URL. For example, to install the ``devel`` branch, use:
+
+   .. code-block:: bash
+
+      pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git@devel
+   
+   This is useful if you want to test new features or bug fixes that are not yet in the main branch.
+
+
 4. Copy the profile file to your home directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -343,6 +377,16 @@ Install CAP from the `NASA Planetary Science GitHub <https://github.com/NASA-Pla
 
    pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git
 
+.. note::
+
+   You can install a specific branch of the AmesCAP repository by appending ``@branch_name`` to the URL. For example, to install the ``devel`` branch, use:
+
+   .. code-block:: bash
+
+      pip install git+https://github.com/NASA-Planetary-Science/AmesCAP.git@devel
+   
+   This is useful if you want to test new features or bug fixes that are not yet in the main branch.
+
 5. Copy the profile file to your home directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -384,7 +428,9 @@ Troubleshooting Tips
 Spectral Analysis Capabilities
 -----------------------------
 
-CAP includes optional spectral analysis capabilities that require additional dependencies. These capabilities leverage the ``pyshtools`` library for spherical harmonic transforms and other spectral analysis functions.
+CAP includes optional spectral analysis capabilities that require additional dependencies (spatial filtering utilities). These capabilities leverage the ``pyshtools`` library for spherical harmonic transforms and other spectral analysis functions. ``pyshtools`` is a powerful library for working with spherical harmonics and it is an optional dependencies because it can be complex to install. It requires several system-level dependencies, including `libfftw3 <http://www.fftw.org/>`_ and `liblapack <http://www.netlib.org/lapack/>`_ and BLAS libraries, plus Fortran and C compilers. These dependencies are not included in the standard Python installation and may require additional setup.
+
+If you are using a conda environment, these dependencies are automatically installed when you create the environment using the provided ``environment.yml`` file. If you are using pip, you will need to install these dependencies manually. 
 
 Installing with Spectral Analysis Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -393,16 +439,31 @@ There are two recommended ways to install CAP with spectral analysis support:
 
 **Method 1: Using conda (recommended)**
 
-The conda installation method is recommended as it handles all the complex dependencies automatically:
+The conda installation method is recommended as it handles all the complex dependencies automatically. You may need to modify these instructions for your specific system, but the following should work on most systems:
 
 .. code-block:: bash
 
    # Clone the repository
-   git clone https://github.com/NASA-Planetary-Science/AmesCAP.git
+   git clone clone -b pyshtools https://github.com/NASA-Planetary-Science/AmesCAP.git
    cd AmesCAP
    
    # Create conda environment with all dependencies including pyshtools
-   conda env create -f environment.yml
+   conda env create -f environment.yml -n amescap python=3.13
    
    # Activate the environment
    conda activate amescap
+
+   # It is safe to remove the clone after install
+   cd .. # Move out of the AmesCAP repository
+   rm -rf AmesCAP # Remove the cloned repository
+
+**Method 1: Using pip**
+
+The pip installation method is less recommended as it requires manual installation of the dependencies. If you choose this method, you will need to install the dependencies separately. The following command will install CAP with spectral analysis support:
+
+.. code-block:: bash
+
+   # Create your virtual environment according to the instructions above
+
+   # Install CAP with spectral analysis support
+   pip install "amescap[spectral] @ git+https://github.com/NASA-Planetary-Science/AmesCAP.git@pyshtools"

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,6 +10,7 @@ Installing CAP is done on the command line via ``git clone``. Here, we provide i
 :ref:`MacOS Installation <mac_install>`
 :ref:`Windows Installation <windows_install>`
 :ref:`NAS Installation <nas_install>`
+:ref:`Spectral Analysis Capabilities <spectral_analysis>`
 
 .. _mac_install:
 
@@ -376,3 +377,32 @@ Troubleshooting Tips
 * **Profile File Not Found**: Double-check the installation paths. The actual path may vary depending on your specific installation.
 * **Python Version**: If you need a different Python version, check available modules with ``module avail python``.
 * **Shell Type**: If you're unsure which shell you're using, run ``echo $SHELL`` to determine your current shell type.
+
+
+.. _spectral_analysis:
+
+Spectral Analysis Capabilities
+-----------------------------
+
+CAP includes optional spectral analysis capabilities that require additional dependencies. These capabilities leverage the ``pyshtools`` library for spherical harmonic transforms and other spectral analysis functions.
+
+Installing with Spectral Analysis Support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are two recommended ways to install CAP with spectral analysis support:
+
+**Method 1: Using conda (recommended)**
+
+The conda installation method is recommended as it handles all the complex dependencies automatically:
+
+.. code-block:: bash
+
+   # Clone the repository
+   git clone https://github.com/NASA-Planetary-Science/AmesCAP.git
+   cd AmesCAP
+   
+   # Create conda environment with all dependencies including pyshtools
+   conda env create -f environment.yml
+   
+   # Activate the environment
+   conda activate amescap

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -447,14 +447,23 @@ The conda installation method is recommended as it handles all the complex depen
    cd AmesCAP
    
    # Create conda environment with all dependencies including pyshtools
-   conda env create -f environment.yml -n amescap python=3.13
+   conda env create -f environment.yml -n amescap
    
    # Activate the environment
    conda activate amescap
 
+   # Install the package with spectral analysis support
+   pip install .[spectral]
+
    # It is safe to remove the clone after install
    cd .. # Move out of the AmesCAP repository
    rm -rf AmesCAP # Remove the cloned repository
+
+   # Don't forget to copy the profile file to your home directory
+   cp /opt/anaconda3/envs/amescap/mars_templates/amescap_profile ~/.amescap_profile
+
+   # To deactivate the environment, run:
+   conda deactivate
 
 **Method 1: Using pip**
 
@@ -462,7 +471,15 @@ The pip installation method is less recommended as it requires manual installati
 
 .. code-block:: bash
 
-   # Create your virtual environment according to the instructions above
+   # Create your virtual environment with pip according to the instructions above. Make sure to follow the instructions for your operating system.
+
+   # Activate your virtual environment
 
    # Install CAP with spectral analysis support
    pip install "amescap[spectral] @ git+https://github.com/NASA-Planetary-Science/AmesCAP.git@pyshtools"
+
+   # Don't forget to copy the profile file to your home directory
+   cp amescap/mars_templates/amescap_profile ~/.amescap_profile
+   
+   # To deactivate the environment, run:
+   deactivate

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: amescap
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.8
+  - netcdf4>=1.6.5
+  - numpy>=1.26.2
+  - matplotlib>=3.8.2
+  - scipy>=1.11.4
+  - xarray>=2023.5.0
+  - pandas>=2.0.3
+  - pyodbc>=4.0.39
+  - pyshtools
+  - pip
+  - pip:
+    - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+spectral = ["pyshtools>=4.10.0"]
 dev = [
   "sphinx>=7.2.6",
   "sphinx-rtd-theme>=1.3.0rc1",


### PR DESCRIPTION
This fix enables spatial filtering (low high and band pass) with the pyshtools install, provided users install that dependency. The instructions offer two solutions to installing pyshtools. For installs without pyshtools, an error message will show explaining that pyshtools is required to use -lps, -bps, -hps.

MarsFiles' command-line help was updated with the message:

```
REQUIRES SPECIAL INSTALL: See 'Spectral Analysis Capabilities' in the installation instructions at https://amescap.readthedocs.io/en/latest/installation.html

Trying to use spatial filters without installing pyshtools gives the error:
__________________
Zonal decomposition relies on the pyshtools library, referenced at:

Mark A. Wieczorek and Matthias Meschede (2018). SHTools - Tools for working with spherical harmonics,Geochemistry, Geophysics, Geosystems, 2574-2592, doi:10.1029/2018GC007529

Please consult pyshtools  documentation at:
 https://pypi.org/project/pyshtools
And installation instructions for CAP with pyshtools:
 https://amescap.readthedocs.io/en/latest/installation.html#_spectral_analysis
__________________

ERROR in main: cannot import name 'init_shtools' from 'amescap.Spectral_utils' (/Users/cbatters/amescap-test/lib/python3.11/site-packages/amescap/Spectral_utils.py)
Use --debug for more information.
```

Also updated the installation instructions for a conda or pip installation of the pyshtools dependencies.



